### PR TITLE
Split networks

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,7 @@ import {
   SafeListeners,
   InterfaceMessageIds,
   InterfaceMessageEvent,
-  Networks,
+  LowercaseNetworks,
   SDKMessageToPayload,
   SDKMessageIds,
   Transaction,
@@ -35,7 +35,7 @@ const _handleMessageFromInterface = async <T extends InterfaceMessageIds>(
 
       config.listeners?.onSafeInfo({
         safeAddress: typedPayload.safeAddress,
-        network: typedPayload.network.toLowerCase() as Networks,
+        network: typedPayload.network.toLowerCase() as LowercaseNetworks,
         ethBalance: typedPayload.ethBalance,
       });
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -5,21 +5,9 @@ import { INTERFACE_MESSAGES, SDK_MESSAGES } from './messageIds';
     type for networks contains uppercase strings and with previous type it resulted in a type error.
     The sdk converts network to lowercase, so passing an uppercase one is totally valid too.
 */
-export type Networks =
-  | 'MAINNET'
-  | 'MORDEN'
-  | 'ROPSTEN'
-  | 'RINKEBY'
-  | 'GOERLI'
-  | 'KOVAN'
-  | 'UNKNOWN'
-  | 'mainnet'
-  | 'morden'
-  | 'ropsten'
-  | 'rinkeby'
-  | 'goerli'
-  | 'kovan'
-  | 'unknown';
+export type UppercaseNetworks = 'MAINNET' | 'MORDEN' | 'ROPSTEN' | 'RINKEBY' | 'GOERLI' | 'KOVAN' | 'UNKNOWN';
+export type LowercaseNetworks = 'mainnet' | 'morden' | 'ropsten' | 'rinkeby' | 'goerli' | 'kovan' | 'unknown';
+export type Networks = UppercaseNetworks | LowercaseNetworks;
 
 export interface Transaction {
   to: string;
@@ -37,7 +25,7 @@ export interface SdkInstance {
 
 export interface SafeInfo {
   safeAddress: string;
-  network: Networks;
+  network: LowercaseNetworks;
   ethBalance: string;
 }
 


### PR DESCRIPTION
This PR redefines the `Network` type as a union of `LowercaseNetworks` and `UppercaseNetworks`. 
Then the `network` key of `SafeInfo` type was changed to return `LowercaseNetworks`. 