### PR TITLE
Add providedBy manifest info to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ It is mandatory that your app exposes a `manifest.json` file in the root dir wit
   "name": "YourAppName",
   "description": "A description of what your app do",
   "iconPath": "myAppIcon.svg",
-  "providedBy": {"name": 'YourCompanyName', "url": 'https://yourcompanyname.io'}
+  "providedBy": { "name": "YourCompanyName", "url": "https://yourcompanyname.io" }
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -127,7 +127,8 @@ It is mandatory that your app exposes a `manifest.json` file in the root dir wit
 {
   "name": "YourAppName",
   "description": "A description of what your app do",
-  "iconPath": "myAppIcon.svg"
+  "iconPath": "myAppIcon.svg",
+  "providedBy": {"name": 'YourCompanyName', "url": 'https://yourcompanyname.io'}
 }
 ```
 


### PR DESCRIPTION
Safe App developers should also be advised to add the providedBy information to the manifest. While we do not yet expose this information to users, we do plan to do so in the future: https://github.com/gnosis/safe-react/issues/514