### PR TITLE
Bug: Fix network type in safe info

### DIFF
--- a/packages/safe-apps-sdk/src/sdk.ts
+++ b/packages/safe-apps-sdk/src/sdk.ts
@@ -1,5 +1,5 @@
 import { METHODS } from './communication';
-import { Communicator, SafeInfo, EnvInfo } from './types';
+import { Communicator, SafeInfoV1, EnvInfo } from './types';
 import InterfaceCommunicator from './communication';
 import { TXs } from './txs';
 import { Eth } from './eth';
@@ -42,8 +42,11 @@ class SafeAppsSDK {
     return response.data;
   }
 
-  async getSafeInfo(): Promise<SafeInfo> {
-    const response = await this.#communicator.send<'getSafeInfo', undefined, SafeInfo>(METHODS.getSafeInfo, undefined);
+  async getSafeInfo(): Promise<SafeInfoV1> {
+    const response = await this.#communicator.send<'getSafeInfo', undefined, SafeInfoV1>(
+      METHODS.getSafeInfo,
+      undefined,
+    );
 
     if (!response.success) {
       throw new Error(response.error);

--- a/packages/safe-apps-sdk/src/types.ts
+++ b/packages/safe-apps-sdk/src/types.ts
@@ -63,6 +63,11 @@ export interface SafeInfo {
   network: LowercaseNetworks;
 }
 
+export interface SafeInfoV1 {
+  safeAddress: string;
+  network: UppercaseNetworks;
+}
+
 export type Methods = keyof typeof METHODS;
 
 export type SDKRequestData<M extends Methods = Methods, P = unknown> = {


### PR DESCRIPTION
When updating safe-react-apps I stumbled upon a bug where the return value of the network was in uppercase but the type was in lowercase

https://github.com/gnosis/safe-react/blob/0ecd70fdbcd94952ce82acd00dbfbaaaa4ec1f74/src/config/index.ts#L18
https://github.com/gnosis/safe-react/blob/0ecd70fdbcd94952ce82acd00dbfbaaaa4ec1f74/src/config/networks/network.d.ts

This PR fixes that by changing the type from lowercase to uppercase (faster than updating the interface and there's no real need to return the lowercase one)