### PR TITLE
Fix cra-template-safe-app link

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ You can find more resources on Safe Apps in the [Gnosis Safe Developer Portal](h
 
 | Package                                                                                                                                                                                                                        | Description                                   |
 | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | :-------------------------------------------- |
-| [safe-app-cra-template](https://github.com/gnosis/safe-apps-sdk/tree/master/packages/safe-app-cra-template)                                                                                                                    | CRA template to quickly bootstrap a Safe app  |
+| [cra-template-safe-app](https://github.com/gnosis/safe-apps-sdk/tree/master/packages/cra-template-safe-app)                                                                                                                    | CRA template to quickly bootstrap a Safe app  |
 | [safe-apps-react-sdk](https://github.com/gnosis/safe-apps-sdk/tree/master/packages/safe-apps-react-sdk)                                                                                                                        | A wrapper of safe-apps-sdk with helpful hooks |
 | [safe-apps-sdk](https://github.com/gnosis/safe-apps-sdk/tree/master/packages/safe-apps-sdk) [![npm version](https://badge.fury.io/js/%40gnosis.pm%2Fsafe-apps-sdk.svg)](https://badge.fury.io/js/%40gnosis.pm%2Fsafe-apps-sdk) | JavaScript SDK                                |
 


### PR DESCRIPTION
Link pointing to `cra-template-safe-app` package in the README file was broken