### PR TITLE
1.0.3 sdk and 1.0.1 react-sdk releases to master

### DIFF
--- a/packages/safe-apps-react-sdk/README.md
+++ b/packages/safe-apps-react-sdk/README.md
@@ -9,7 +9,7 @@ This sdk should provide a simple way to write a React.js [Safe app](https://docs
 - Add npm package
 
 ```bash
-yarn add @rmeissner/safe-apps-react-sdk
+yarn add @gnosis.pm/safe-apps-react-sdk
 ```
 
 - Add `SafeProvider`  
@@ -17,7 +17,7 @@ yarn add @rmeissner/safe-apps-react-sdk
 
 ```js
 // ... other imports
-import SafeProvider from '@rmeissner/safe-apps-react-sdk';
+import SafeProvider from '@gnosis.pm/safe-apps-react-sdk';
 
 ReactDOM.render(
   <React.StrictMode>
@@ -33,7 +33,7 @@ ReactDOM.render(
 
 ```js
 // ... other imports
-import { useSafeAppsSDK } from '@rmeissner/safe-apps-react-sdk';
+import { useSafeAppsSDK } from '@gnosis.pm/safe-apps-react-sdk';
 
 const App = () => {
   const { sdk, connected, safe } = useSafeAppsSDK();

--- a/packages/safe-apps-react-sdk/package.json
+++ b/packages/safe-apps-react-sdk/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@gnosis.pm/safe-apps-react-sdk",
   "private": false,
-  "version": "1.0.0",
+  "version": "1.0.1",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "license": "MIT",
@@ -11,7 +11,7 @@
   ],
   "author": "Gnosis (https://gnosis.pm)",
   "dependencies": {
-    "@gnosis.pm/safe-apps-sdk": "1.0.0-beta.5",
+    "@gnosis.pm/safe-apps-sdk": "1.0.3-beta.0",
     "@types/jest": "^26.0.19"
   },
   "peerDependencies": {

--- a/packages/safe-apps-react-sdk/src/index.tsx
+++ b/packages/safe-apps-react-sdk/src/index.tsx
@@ -17,7 +17,7 @@ interface Props {
 export const SafeProvider: React.FC<Props> = ({ loader = null, opts, children }) => {
   const [sdk] = useState(new SafeAppsSDK(opts));
   const [connected, setConnected] = useState(false);
-  const [safe, setSafe] = useState<SafeInfo>({ safeAddress: '', network: 'rinkeby' });
+  const [safe, setSafe] = useState<SafeInfo>({ safeAddress: '', network: 'RINKEBY' });
   const contextValue = useMemo(() => ({ sdk, connected, safe }), [sdk, connected, safe]);
 
   useEffect(() => {

--- a/packages/safe-apps-sdk/package.json
+++ b/packages/safe-apps-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gnosis.pm/safe-apps-sdk",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "SDK developed to integrate third-party apps with Safe-Multisig app.",
   "main": "dist/src/index.js",
   "typings": "dist/src/index.d.ts",

--- a/packages/safe-apps-sdk/src/sdk.ts
+++ b/packages/safe-apps-sdk/src/sdk.ts
@@ -1,5 +1,5 @@
 import { METHODS } from './communication';
-import { Communicator, SafeInfoV1, EnvInfo } from './types';
+import { Communicator, SafeInfo, EnvInfo } from './types';
 import InterfaceCommunicator from './communication';
 import { TXs } from './txs';
 import { Eth } from './eth';
@@ -42,11 +42,8 @@ class SafeAppsSDK {
     return response.data;
   }
 
-  async getSafeInfo(): Promise<SafeInfoV1> {
-    const response = await this.#communicator.send<'getSafeInfo', undefined, SafeInfoV1>(
-      METHODS.getSafeInfo,
-      undefined,
-    );
+  async getSafeInfo(): Promise<SafeInfo> {
+    const response = await this.#communicator.send<'getSafeInfo', undefined, SafeInfo>(METHODS.getSafeInfo, undefined);
 
     if (!response.success) {
       throw new Error(response.error);

--- a/packages/safe-apps-sdk/src/types.ts
+++ b/packages/safe-apps-sdk/src/types.ts
@@ -3,12 +3,7 @@ import { RPC_CALLS } from './eth/constants';
 import { TXs } from './txs';
 import { Eth } from './eth';
 
-/*
-    The reason for duplicating types in both uppercase/lowercase is because in the safe-react
-    type for networks contains uppercase strings and with previous type it resulted in a type error.
-    The sdk converts network to lowercase, so passing an uppercase one is totally valid too.
-*/
-export type UppercaseNetworks =
+export type Networks =
   | 'MAINNET'
   | 'MORDEN'
   | 'ROPSTEN'
@@ -19,18 +14,6 @@ export type UppercaseNetworks =
   | 'ENERGY_WEB_CHAIN'
   | 'VOLTA'
   | 'UNKNOWN';
-export type LowercaseNetworks =
-  | 'mainnet'
-  | 'morden'
-  | 'ropsten'
-  | 'rinkeby'
-  | 'goerli'
-  | 'kovan'
-  | 'xdai'
-  | 'energy_web_chain'
-  | 'volta'
-  | 'unknown';
-export type Networks = UppercaseNetworks | LowercaseNetworks;
 
 export interface Transaction {
   to: string;
@@ -60,12 +43,7 @@ export interface SdkInstance {
 
 export interface SafeInfo {
   safeAddress: string;
-  network: LowercaseNetworks;
-}
-
-export interface SafeInfoV1 {
-  safeAddress: string;
-  network: UppercaseNetworks;
+  network: Networks;
 }
 
 export type Methods = keyof typeof METHODS;

--- a/yarn.lock
+++ b/yarn.lock
@@ -470,6 +470,14 @@
     unique-filename "^1.1.1"
     which "^1.3.1"
 
+"@gnosis.pm/safe-apps-sdk@1.0.3-beta.0":
+  version "1.0.3-beta.0"
+  resolved "https://registry.yarnpkg.com/@gnosis.pm/safe-apps-sdk/-/safe-apps-sdk-1.0.3-beta.0.tgz#637100b47f31da284f9d83a043ccc4ed6be44348"
+  integrity sha512-nM2Yl5tU0f3w+eEgLqHcrXCyN/CSme1FYBJesZHTEULlzOA2DMLq1mLvUDXGRVPJD74MaVoc5GiDC9mLNE3ZCw==
+  dependencies:
+    semver "^7.3.2"
+    web3-core "^1.3.0"
+
 "@istanbuljs/load-nyc-config@^1.0.0":
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz#fd3db1d59ecf7cf121e80650bb86712f9b55eced"
@@ -646,7 +654,7 @@
     source-map "^0.6.1"
     write-file-atomic "^3.0.0"
 
-"@jest/types@^26.6.2":
+"@jest/types@^26.3.0", "@jest/types@^26.6.2":
   version "26.6.2"
   resolved "https://registry.yarnpkg.com/@jest/types/-/types-26.6.2.tgz#bef5a532030e1d88a2f5a6d933f84e97226ed48e"
   integrity sha512-fC6QCp7Sc5sX6g8Tvbmj4XUTbyrik0akgRy03yjXbQaBWWNWGE7SGtJk98m0N8nzegD/7SggrUlivxo5ax4KWQ==


### PR DESCRIPTION
I fucked up a little by running `npm publish --beta` instead of `npm publish --tag beta` and packages got published as the latest versions 🤦 

## Safe Apps SDK V1.0.3
- Fix network type in SafeInfo (https://github.com/gnosis/safe-apps-sdk/pull/78)

## Safe Apps React SDK V1.0.1
- Update to the SDK V1.0.3