### PR TITLE
Improve tx handling; remove web3-core dependency

### DIFF
--- a/packages/cra-template-safe-app/template.json
+++ b/packages/cra-template-safe-app/template.json
@@ -2,7 +2,7 @@
   "package": {
     "homepage": "./",
     "dependencies": {
-      "@gnosis.pm/safe-apps-react-sdk": "2.1.0",
+      "@gnosis.pm/safe-apps-react-sdk": "2.2.0",
       "@gnosis.pm/safe-react-components": "^0.3.0",
       "@material-ui/core": "^4.11.0",
       "@testing-library/jest-dom": "^5.11.4",

--- a/packages/safe-apps-ethers-provider/package.json
+++ b/packages/safe-apps-ethers-provider/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gnosis.pm/safe-apps-ethers-provider",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "An ethers.js provider wrapper of Safe Apps SDK",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",
@@ -27,6 +27,6 @@
     "@ethersproject/logger": "^5.0.9",
     "@ethersproject/properties": "^5.0.8",
     "@ethersproject/providers": "^5.0.22",
-    "@gnosis.pm/safe-apps-sdk": "2.1.0"
+    "@gnosis.pm/safe-apps-sdk": "2.2.0"
   }
 }

--- a/packages/safe-apps-onboard/package.json
+++ b/packages/safe-apps-onboard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gnosis.pm/safe-apps-onboard",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "An Onboard.js wrapper for Safe App support",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",
@@ -29,6 +29,6 @@
     "bnc-onboard": "^1.20.0"
   },
   "dependencies": {
-    "@gnosis.pm/safe-apps-provider": "^0.1.0"
+    "@gnosis.pm/safe-apps-provider": "^0.2.0"
   }
 }

--- a/packages/safe-apps-provider/package.json
+++ b/packages/safe-apps-provider/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gnosis.pm/safe-apps-provider",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "A provider wrapper of Safe Apps SDK",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",
@@ -20,6 +20,6 @@
   },
   "homepage": "https://github.com/gnosis/safe-apps-sdk#readme",
   "dependencies": {
-    "@gnosis.pm/safe-apps-sdk": "2.1.0"
+    "@gnosis.pm/safe-apps-sdk": "2.2.0"
   }
 }

--- a/packages/safe-apps-provider/src/provider.ts
+++ b/packages/safe-apps-provider/src/provider.ts
@@ -1,4 +1,4 @@
-import SafeAppsSDK, { SafeInfo, Web3TransactionObject, Web3TransactionReceiptObject } from '@gnosis.pm/safe-apps-sdk';
+import SafeAppsSDK, { SafeInfo, Web3TransactionObject } from '@gnosis.pm/safe-apps-sdk';
 import { getLowerCase } from './utils';
 
 const NETWORK_CHAIN_ID: Record<string, number> = {
@@ -110,7 +110,7 @@ export class SafeAppProvider implements AsyncSendable {
         if (this.submittedTxs.has(txHash)) {
           return this.submittedTxs.get(txHash);
         }
-        return this.sdk.eth.getTransactionByHash([txHash]).then((tx: Web3TransactionObject) => {
+        return this.sdk.eth.getTransactionByHash([txHash]).then((tx) => {
           // We set the tx hash to the one requested, as some provider assert this
           if (tx) {
             tx.hash = params[0];
@@ -124,7 +124,7 @@ export class SafeAppProvider implements AsyncSendable {
           const resp = await this.sdk.txs.getBySafeTxHash(txHash);
           txHash = resp.transactionHash || txHash;
         } catch (e) {}
-        return this.sdk.eth.getTransactionReceipt([txHash]).then((tx: Web3TransactionReceiptObject) => {
+        return this.sdk.eth.getTransactionReceipt([txHash]).then((tx) => {
           // We set the tx hash to the one requested, as some provider assert this
           if (tx) {
             tx.transactionHash = params[0];

--- a/packages/safe-apps-provider/src/provider.ts
+++ b/packages/safe-apps-provider/src/provider.ts
@@ -1,4 +1,4 @@
-import SafeAppsSDK, { SafeInfo, Web3TransactionObject } from '@gnosis.pm/safe-apps-sdk';
+import SafeAppsSDK, { SafeInfo, Web3TransactionObject, Web3TransactionReceiptObject } from '@gnosis.pm/safe-apps-sdk';
 import { getLowerCase } from './utils';
 
 const NETWORK_CHAIN_ID: Record<string, number> = {
@@ -110,8 +110,7 @@ export class SafeAppProvider implements AsyncSendable {
         if (this.submittedTxs.has(txHash)) {
           return this.submittedTxs.get(txHash);
         }
-        // eslint-disable-next-line
-        return this.sdk.eth.getTransactionByHash([txHash]).then((tx: any) => {
+        return this.sdk.eth.getTransactionByHash([txHash]).then((tx: Web3TransactionObject) => {
           // We set the tx hash to the one requested, as some provider assert this
           if (tx) {
             tx.hash = params[0];
@@ -125,8 +124,7 @@ export class SafeAppProvider implements AsyncSendable {
           const resp = await this.sdk.txs.getBySafeTxHash(txHash);
           txHash = resp.transactionHash || txHash;
         } catch (e) {}
-        // eslint-disable-next-line
-        return this.sdk.eth.getTransactionReceipt([txHash]).then((tx: any) => {
+        return this.sdk.eth.getTransactionReceipt([txHash]).then((tx: Web3TransactionReceiptObject) => {
           // We set the tx hash to the one requested, as some provider assert this
           if (tx) {
             tx.transactionHash = params[0];

--- a/packages/safe-apps-provider/src/provider.ts
+++ b/packages/safe-apps-provider/src/provider.ts
@@ -20,7 +20,7 @@ type AsyncSendable = {
 export class SafeAppProvider implements AsyncSendable {
   private readonly safe: SafeInfo;
   private readonly sdk: SafeAppsSDK;
-  private submittedTxs = new Map<string, Web3TransactionObject>()
+  private submittedTxs = new Map<string, Web3TransactionObject>();
 
   constructor(safe: SafeInfo, sdk: SafeAppsSDK) {
     this.safe = safe;
@@ -60,7 +60,7 @@ export class SafeAppProvider implements AsyncSendable {
           value: '0',
           data: '0x',
           ...params[0],
-        }
+        };
         const resp = await this.sdk.txs.send({
           txs: [tx],
         });
@@ -69,15 +69,15 @@ export class SafeAppProvider implements AsyncSendable {
           from: this.safe.safeAddress,
           hash: resp.safeTxHash,
           gas: 0,
-          gasPrice: "0x00",
+          gasPrice: '0x00',
           nonce: 0,
           input: tx.data,
           value: tx.value,
           to: tx.to,
           blockHash: null,
           blockNumber: null,
-          transactionIndex: null
-        })
+          transactionIndex: null,
+        });
         return resp.safeTxHash;
 
       case 'eth_blockNumber':
@@ -105,12 +105,13 @@ export class SafeAppProvider implements AsyncSendable {
         try {
           const resp = await this.sdk.txs.getBySafeTxHash(txHash);
           txHash = resp.transactionHash || txHash;
-        } catch (e) { }
+        } catch (e) {}
         // Use fake transaction if we don't have a real tx hash
         if (this.submittedTxs.has(txHash)) {
-          return this.submittedTxs.get(txHash)
+          return this.submittedTxs.get(txHash);
         }
-        return this.sdk.eth.getTransactionByHash([txHash]).then((tx) => {
+        // eslint-disable-next-line
+        return this.sdk.eth.getTransactionByHash([txHash]).then((tx: any) => {
           // We set the tx hash to the one requested, as some provider assert this
           if (tx) {
             tx.hash = params[0];
@@ -123,8 +124,9 @@ export class SafeAppProvider implements AsyncSendable {
         try {
           const resp = await this.sdk.txs.getBySafeTxHash(txHash);
           txHash = resp.transactionHash || txHash;
-        } catch (e) { }
-        return this.sdk.eth.getTransactionReceipt([txHash]).then((tx) => {
+        } catch (e) {}
+        // eslint-disable-next-line
+        return this.sdk.eth.getTransactionReceipt([txHash]).then((tx: any) => {
           // We set the tx hash to the one requested, as some provider assert this
           if (tx) {
             tx.transactionHash = params[0];

--- a/packages/safe-apps-react-sdk/package.json
+++ b/packages/safe-apps-react-sdk/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@gnosis.pm/safe-apps-react-sdk",
   "private": false,
-  "version": "2.1.0",
+  "version": "2.2.0",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "license": "MIT",
@@ -11,7 +11,7 @@
   ],
   "author": "Gnosis (https://gnosis.io)",
   "dependencies": {
-    "@gnosis.pm/safe-apps-sdk": "2.1.0",
+    "@gnosis.pm/safe-apps-sdk": "2.2.0",
     "@types/jest": "^26.0.20"
   },
   "peerDependencies": {

--- a/packages/safe-apps-sdk/package.json
+++ b/packages/safe-apps-sdk/package.json
@@ -36,7 +36,6 @@
     "prettier": "^2.2.1",
     "rimraf": "^3.0.2"
   },
-  "peerDependencies": {},
   "husky": {
     "hooks": {
       "pre-commit": "lint-staged"

--- a/packages/safe-apps-sdk/package.json
+++ b/packages/safe-apps-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gnosis.pm/safe-apps-sdk",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "description": "SDK developed to integrate third-party apps with Safe-Multisig app.",
   "main": "dist/src/index.js",
   "typings": "dist/src/index.d.ts",
@@ -24,8 +24,7 @@
   "author": "Gnosis (https://gnosis.io)",
   "license": "MIT",
   "dependencies": {
-    "semver": "^7.3.2",
-    "web3-core": "^1.3.0"
+    "semver": "^7.3.2"
   },
   "devDependencies": {
     "@types/jest": "^26.0.20",
@@ -37,9 +36,7 @@
     "prettier": "^2.2.1",
     "rimraf": "^3.0.2"
   },
-  "peerDependencies": {
-    "web3-core": "^1.3.0"
-  },
+  "peerDependencies": {},
   "husky": {
     "hooks": {
       "pre-commit": "lint-staged"

--- a/packages/safe-apps-sdk/src/eth/eth.test.ts
+++ b/packages/safe-apps-sdk/src/eth/eth.test.ts
@@ -1,6 +1,6 @@
-import { TransactionConfig, PastLogsOptions } from 'web3-core';
 import SDK from '../index';
 import { METHODS } from '../communication';
+import { PastLogsOptions, TransactionConfig } from '../types';
 
 describe('Safe Apps SDK Read RPC Requests', () => {
   const sdkInstance = new SDK({ whitelistedDomains: [/http:\/\/localhost:3000/] });

--- a/packages/safe-apps-sdk/src/eth/index.ts
+++ b/packages/safe-apps-sdk/src/eth/index.ts
@@ -1,6 +1,6 @@
-import { TransactionConfig, PastLogsOptions } from 'web3-core';
 import { RPC_CALLS } from '../eth/constants';
 import {
+  BlockNumberArg,
   RpcCallNames,
   Communicator,
   Log,
@@ -8,14 +8,14 @@ import {
   BlockTransactionObject,
   Web3TransactionObject,
   RPCPayload,
+  TransactionConfig,
   Web3TransactionReceiptObject,
+  PastLogsOptions,
 } from '../types';
 import { METHODS } from '../communication/methods';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type Formatter = (arg: any) => any;
-
-type BlockNumberArg = number | 'earliest' | 'latest' | 'pending';
 
 const inputFormatters: Record<string, Formatter> = {
   defaultBlockParam: (arg = 'latest') => arg,

--- a/packages/safe-apps-sdk/src/types.ts
+++ b/packages/safe-apps-sdk/src/types.ts
@@ -270,3 +270,22 @@ export interface Web3TransactionReceiptObject {
   logsBloom: string;
   status: number | undefined;
 }
+
+export type BlockNumberArg = number | 'earliest' | 'latest' | 'pending';
+
+export interface TransactionConfig {
+  from?: string | number;
+  to?: string;
+  value?: number | string;
+  gas?: number | string;
+  gasPrice?: number | string;
+  data?: string;
+  nonce?: number;
+}
+
+export interface PastLogsOptions {
+  fromBlock?: BlockNumberArg;
+  toBlock?: BlockNumberArg;
+  address?: string;
+  topics?: Array<string | string[] | null>;
+}

--- a/packages/safe-apps-web3modal/package.json
+++ b/packages/safe-apps-web3modal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gnosis.pm/safe-apps-web3modal",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "A web3modal wrapper for Safe App support",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",
@@ -29,6 +29,6 @@
     "web3modal": "^1.9.3"
   },
   "dependencies": {
-    "@gnosis.pm/safe-apps-provider": "^0.1.0"
+    "@gnosis.pm/safe-apps-provider": "^0.2.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -11956,7 +11956,7 @@ web3-core-subscriptions@1.3.4:
     underscore "1.9.1"
     web3-core-helpers "1.3.4"
 
-web3-core@1.3.4, web3-core@^1.3.0:
+web3-core@1.3.4:
   version "1.3.4"
   resolved "https://registry.yarnpkg.com/web3-core/-/web3-core-1.3.4.tgz#2cc7ba7f35cc167f7a0a46fd5855f86e51d34ce8"
   integrity sha512-7OJu46RpCEfTerl+gPvHXANR2RkLqAfW7l2DAvQ7wN0pnCzl9nEfdgW6tMhr31k3TR2fWucwKzCyyxMGzMHeSA==


### PR DESCRIPTION
- Improve tx handling: If transaction was submitted via the provider, we will cache a fake tx to be returned in case we cannot load the real one.
- Remove web3-core dependency (TODO: cleanup yarn.lock after each package release)