### PR TITLE
Add support for XDAI in gnosis-app-provider

### DIFF
--- a/packages/safe-apps-provider/src/provider.ts
+++ b/packages/safe-apps-provider/src/provider.ts
@@ -4,6 +4,7 @@ import { getLowerCase } from './utils';
 const NETWORK_CHAIN_ID: Record<string, number> = {
   MAINNET: 1,
   RINKEBY: 4,
+  XDAI: 100,
 };
 
 // taken from ethers.js, compatible interface with web3 provider


### PR DESCRIPTION
Hi team,
While testing my app I noticed that `provider.chainId` returned `undefined` for xDai gnosis safes. 
This is my attempt at fixing that =)