### PR TITLE
Safe Apps Provider: Add xdai chain network id

### DIFF
--- a/packages/safe-apps-onboard/package.json
+++ b/packages/safe-apps-onboard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gnosis.pm/safe-apps-onboard",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "An Onboard.js wrapper for Safe App support",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",
@@ -33,6 +33,6 @@
     "bnc-onboard": "^1.20.0"
   },
   "dependencies": {
-    "@gnosis.pm/safe-apps-provider": "^0.2.0"
+    "@gnosis.pm/safe-apps-provider": "0.2.4"
   }
 }

--- a/packages/safe-apps-provider/package.json
+++ b/packages/safe-apps-provider/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gnosis.pm/safe-apps-provider",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "description": "A provider wrapper of Safe Apps SDK",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",

--- a/packages/safe-apps-provider/src/provider.ts
+++ b/packages/safe-apps-provider/src/provider.ts
@@ -4,6 +4,7 @@ import { getLowerCase } from './utils';
 const NETWORK_CHAIN_ID: Record<string, number> = {
   MAINNET: 1,
   RINKEBY: 4,
+  XDAI: 100,
 };
 
 // taken from ethers.js, compatible interface with web3 provider

--- a/packages/safe-apps-web3-react/package.json
+++ b/packages/safe-apps-web3-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gnosis.pm/safe-apps-web3-react",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Web3-react connector for Safe Apps",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",
@@ -24,7 +24,7 @@
   "license": "MIT",
   "dependencies": {
     "@web3-react/abstract-connector": "6.0.7",
-    "@gnosis.pm/safe-apps-provider": "0.2.2",
+    "@gnosis.pm/safe-apps-provider": "0.2.4",
     "@gnosis.pm/safe-apps-sdk": "2.2.0"
   },
   "peerDependencies": {

--- a/packages/safe-apps-web3modal/package.json
+++ b/packages/safe-apps-web3modal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gnosis.pm/safe-apps-web3modal",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "A web3modal wrapper for Safe App support",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",
@@ -33,6 +33,6 @@
     "web3modal": "^1.9.3"
   },
   "dependencies": {
-    "@gnosis.pm/safe-apps-provider": "^0.2.0"
+    "@gnosis.pm/safe-apps-provider": "0.2.4"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -677,13 +677,6 @@
     unique-filename "^1.1.1"
     which "^1.3.1"
 
-"@gnosis.pm/safe-apps-provider@0.2.2":
-  version "0.2.2"
-  resolved "https://registry.yarnpkg.com/@gnosis.pm/safe-apps-provider/-/safe-apps-provider-0.2.2.tgz#ffc4e4205eb77a9dec05d32617e9eda74606fa6f"
-  integrity sha512-rg2sv4Qg4CgtmqDxWHhlmUGkjAMeH/WdFnXH4oFGV41F7cPIWu1sYVcqRVaP4NgObr1WPGP6rWdaCqZBHy0jWA==
-  dependencies:
-    "@gnosis.pm/safe-apps-sdk" "2.2.0"
-
 "@istanbuljs/load-nyc-config@^1.0.0":
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz#fd3db1d59ecf7cf121e80650bb86712f9b55eced"


### PR DESCRIPTION
This PR:
- Closes #128 by adding network id for xdai

In the future we will make the core sdk return the chain id, removing the need to add an id per network