### PR TITLE
Remove test files from build outputs

### DIFF
--- a/packages/safe-apps-sdk/tsconfig.json
+++ b/packages/safe-apps-sdk/tsconfig.json
@@ -3,5 +3,6 @@
   "compilerOptions": {
     "outDir": "./dist"
   },
-  "include": ["./src"]
+  "include": ["./src"],
+  "exclude": ["./src/**/*.test.ts"]
 }

--- a/packages/safe-apps-sdk/tsconfig.json
+++ b/packages/safe-apps-sdk/tsconfig.json
@@ -3,6 +3,5 @@
   "compilerOptions": {
     "outDir": "./dist"
   },
-  "include": ["./src"],
-  "exclude": ["./src/**/*.test.ts"]
+  "include": ["./src"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,5 +18,5 @@
     "resolveJsonModule": true,
     "jsx": "react-jsx"
   },
-  "exclude": ["dist", "node_modules"]
+  "exclude": ["dist", "node_modules", "./**/*.test.ts"]
 }


### PR DESCRIPTION
The tests for the sdk are being included in the build outputs and increasing the size of the package whereas we can safely remove them.