### PR TITLE
Bug: Don't call setState on an unmounted component

### DIFF
--- a/packages/safe-apps-react-sdk/src/index.tsx
+++ b/packages/safe-apps-react-sdk/src/index.tsx
@@ -21,18 +21,29 @@ export const SafeProvider: React.FC<Props> = ({ loader = null, opts, children })
   const contextValue = useMemo(() => ({ sdk, connected, safe }), [sdk, connected, safe]);
 
   useEffect(() => {
+    let active = true;
     const fetchSafeInfo = async () => {
       try {
         const safeInfo = await sdk.getSafeInfo();
 
+        if (!active) {
+          return;
+        }
         setSafe(safeInfo);
         setConnected(true);
       } catch (err) {
+        if (!active) {
+          return;
+        }
         setConnected(false);
       }
     };
 
     fetchSafeInfo();
+
+    return () => {
+      active = false;
+    };
   }, [sdk]);
 
   if (!connected && loader) {


### PR DESCRIPTION
This PR:
- uses active flag to make sure the component is mounted

taken from https://github.com/gnosis/safe-apps-sdk/pull/145