### PR TITLE
Decrease bundle size by downgrading semver

### DIFF
--- a/packages/safe-apps-sdk/dist/package.json
+++ b/packages/safe-apps-sdk/dist/package.json
@@ -24,7 +24,7 @@
     "author": "Gnosis (https://gnosis.io)",
     "license": "MIT",
     "dependencies": {
-        "semver": "7.1.1"
+        "semver": "7.1.0"
     },
     "devDependencies": {
         "@types/jest": "^26.0.23",

--- a/packages/safe-apps-sdk/dist/package.json
+++ b/packages/safe-apps-sdk/dist/package.json
@@ -24,12 +24,12 @@
     "author": "Gnosis (https://gnosis.io)",
     "license": "MIT",
     "dependencies": {
-        "semver": "^7.3.2"
+        "semver": "7.1.1"
     },
     "devDependencies": {
         "@types/jest": "^26.0.23",
         "@types/node": "^15.0.1",
-        "@types/semver": "^7.3.5",
+        "@types/semver": "7.1.0",
         "husky": "^6.0.0",
         "lint-staged": "^11.0.0",
         "prettier": "^2.2.1",

--- a/packages/safe-apps-sdk/package.json
+++ b/packages/safe-apps-sdk/package.json
@@ -24,7 +24,7 @@
   "author": "Gnosis (https://gnosis.io)",
   "license": "MIT",
   "dependencies": {
-    "semver": "7.1.1"
+    "semver": "7.1.0"
   },
   "devDependencies": {
     "@types/jest": "^26.0.23",

--- a/packages/safe-apps-sdk/package.json
+++ b/packages/safe-apps-sdk/package.json
@@ -24,12 +24,12 @@
   "author": "Gnosis (https://gnosis.io)",
   "license": "MIT",
   "dependencies": {
-    "semver": "^7.3.2"
+    "semver": "7.1.1"
   },
   "devDependencies": {
     "@types/jest": "^26.0.23",
     "@types/node": "^15.0.1",
-    "@types/semver": "^7.3.5",
+    "@types/semver": "7.1.0",
     "husky": "^6.0.0",
     "lint-staged": "^11.0.0",
     "prettier": "^2.2.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2209,6 +2209,13 @@
   dependencies:
     "@types/node" "*"
 
+"@types/semver@7.1.0":
+  version "7.1.0"
+  resolved "https://registry.yarnpkg.com/@types/semver/-/semver-7.1.0.tgz#c8c630d4c18cd326beff77404887596f96408408"
+  integrity sha512-pOKLaubrAEMUItGNpgwl0HMFPrSAFic8oSVIvfu1UwcgGNmNyK9gyhBHKmBnUTwwVvpZfkzUC0GaMgnL6P86uA==
+  dependencies:
+    "@types/node" "*"
+
 "@types/semver@^7.3.5":
   version "7.3.5"
   resolved "https://registry.yarnpkg.com/@types/semver/-/semver-7.3.5.tgz#74deebbbcb1e86634dbf10a5b5e8798626f5a597"
@@ -9735,6 +9742,11 @@ semver@7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.0.0.tgz#5f3ca35761e47e05b206c6daff2cf814f0316b8e"
   integrity sha512-+GB6zVA9LWh6zovYQLALHwv5rb2PHGlJi3lfiqIHxR0uuwCgefcOJc59v9fv1w8GbStwxuuqqAjI9NMAOOgq1A==
+
+semver@7.1.1:
+  version "7.1.1"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.1.1.tgz#29104598a197d6cbe4733eeecbe968f7b43a9667"
+  integrity sha512-WfuG+fl6eh3eZ2qAf6goB7nhiCd7NPXhmyFxigB/TOkQyeLP8w8GsVehvtGNtnNmyboz4TgeK40B1Kbql/8c5A==
 
 semver@7.x, semver@^7.1.1, semver@^7.1.3, semver@^7.2.1, semver@^7.3.2, semver@^7.3.4, semver@^7.3.5:
   version "7.3.5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -9743,10 +9743,10 @@ semver@7.0.0:
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.0.0.tgz#5f3ca35761e47e05b206c6daff2cf814f0316b8e"
   integrity sha512-+GB6zVA9LWh6zovYQLALHwv5rb2PHGlJi3lfiqIHxR0uuwCgefcOJc59v9fv1w8GbStwxuuqqAjI9NMAOOgq1A==
 
-semver@7.1.1:
-  version "7.1.1"
-  resolved "https://registry.yarnpkg.com/semver/-/semver-7.1.1.tgz#29104598a197d6cbe4733eeecbe968f7b43a9667"
-  integrity sha512-WfuG+fl6eh3eZ2qAf6goB7nhiCd7NPXhmyFxigB/TOkQyeLP8w8GsVehvtGNtnNmyboz4TgeK40B1Kbql/8c5A==
+semver@7.1.0:
+  version "7.1.0"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.1.0.tgz#e5870a302d6929a86a967c346e699e19154e38e0"
+  integrity sha512-4P8Vc43MxQL6UKqSiEnf0jZNYx545R9W1HwXP6p65paPp86AUJiafZ8XG81hAbcldKMCUIbeykUTVYG19LB7Cw==
 
 semver@7.x, semver@^7.1.1, semver@^7.1.3, semver@^7.2.1, semver@^7.3.2, semver@^7.3.4, semver@^7.3.5:
   version "7.3.5"


### PR DESCRIPTION
We got a report that 58% of our bundle is semver: https://github.com/gnosis/safe-apps-sdk/issues/154

According to [bundlephobia](https://bundlephobia.com/result?p=semver@7.1.2), semver's bundle size increased 7times at version 7.1.2 and continued to grow since.

We're not using it heavily so I downgraded it to version 7.1.0 where it weighs 2kb: https://bundlephobia.com/result?p=semver@7.1.0

I used 7.1.0 because @types/semver are version 7.1.0 too, not sure if 7.1.1 is compatible with types 7.1.0