### PR TITLE
Feature: Catch exceptions in communicator

### DIFF
--- a/packages/safe-apps-sdk/src/communication/communicator.test.ts
+++ b/packages/safe-apps-sdk/src/communication/communicator.test.ts
@@ -4,31 +4,21 @@ import PostMessageCommunicator from './';
 import { MessageFormatter } from './messageFormatter';
 
 describe('PostMessageCommunicator', () => {
-  // /* eslint-disable-next-line */
-  // let spy: jest.SpyInstance<void, [message: any, targetOrigin: string, transfer?: Transferable[] | undefined]>;
-
-  // beforeEach(() => {
-  //   spy = jest.spyOn(window.parent, 'postMessage');
-  // });
-
-  // afterEach(() => {
-  //   jest.clearAllMocks();
-  // });
-
   test('Throws in case of an error response', async () => {
+    const error = 'Problem processing the request';
     const messageHandler = (event: SDKMessageEvent) => {
       const requestId = event.data.id;
-      const response = MessageFormatter.makeErrorResponse(requestId, 'Problem processing the request', '1.0.0');
+      const response = MessageFormatter.makeErrorResponse(requestId, error, '1.0.0');
 
       window.parent.postMessage(response, '*');
     };
     window.parent.addEventListener('message', messageHandler);
 
     const communicator = new PostMessageCommunicator();
-    // const message = communicator.send(Methods.getSafeInfo, undefined);
+    // @ts-expect-error mock isValidMessage because source check couldn't be passed otherwise, filter out requests
+    communicator.isValidMessage = (msg) => typeof msg.data.success !== 'undefined';
 
-    await expect(communicator.send(Methods.getSafeInfo, undefined)).rejects.toThrow('Problem processing request');
+    await expect(communicator.send(Methods.getSafeInfo, undefined)).rejects.toThrow(error);
     window.removeEventListener('message', messageHandler);
-    // expect(spy).toHaveBeenCalledWith(expect.objectContaining({ method: Methods.getSafeInfo, params: undefined }), '*');
   });
 });

--- a/packages/safe-apps-sdk/src/communication/communicator.test.ts
+++ b/packages/safe-apps-sdk/src/communication/communicator.test.ts
@@ -1,0 +1,34 @@
+import { SDKMessageEvent } from './../types/messaging';
+import { Methods } from './methods';
+import PostMessageCommunicator from './';
+import { MessageFormatter } from './messageFormatter';
+
+describe('PostMessageCommunicator', () => {
+  // /* eslint-disable-next-line */
+  // let spy: jest.SpyInstance<void, [message: any, targetOrigin: string, transfer?: Transferable[] | undefined]>;
+
+  // beforeEach(() => {
+  //   spy = jest.spyOn(window.parent, 'postMessage');
+  // });
+
+  // afterEach(() => {
+  //   jest.clearAllMocks();
+  // });
+
+  test('Throws in case of an error response', async () => {
+    const messageHandler = (event: SDKMessageEvent) => {
+      const requestId = event.data.id;
+      const response = MessageFormatter.makeErrorResponse(requestId, 'Problem processing the request', '1.0.0');
+
+      window.parent.postMessage(response, '*');
+    };
+    window.parent.addEventListener('message', messageHandler);
+
+    const communicator = new PostMessageCommunicator();
+    // const message = communicator.send(Methods.getSafeInfo, undefined);
+
+    await expect(communicator.send(Methods.getSafeInfo, undefined)).rejects.toThrow('Problem processing request');
+    window.removeEventListener('message', messageHandler);
+    // expect(spy).toHaveBeenCalledWith(expect.objectContaining({ method: Methods.getSafeInfo, params: undefined }), '*');
+  });
+});

--- a/packages/safe-apps-sdk/src/communication/index.ts
+++ b/packages/safe-apps-sdk/src/communication/index.ts
@@ -26,7 +26,7 @@ class PostMessageCommunicator implements Communicator {
     if (Array.isArray(this.allowedOrigins)) {
       validOrigin = this.allowedOrigins.find((regExp) => regExp.test(origin)) !== undefined;
     }
-    console.log({ source, emptyOrMalformed, sentFromParentEl, allowedSDKVersion, validOrigin });
+
     return !emptyOrMalformed && sentFromParentEl && allowedSDKVersion && validOrigin;
   };
 

--- a/packages/safe-apps-sdk/src/communication/index.ts
+++ b/packages/safe-apps-sdk/src/communication/index.ts
@@ -1,6 +1,6 @@
-import { InterfaceMessageEvent, Communicator, Response } from '../types';
 import { MessageFormatter } from './messageFormatter';
 import { Methods } from './methods';
+import { InterfaceMessageEvent, Communicator, Response, SuccessResponse } from '../types';
 
 // eslint-disable-next-line
 type Callback = (response: any) => void;
@@ -26,7 +26,7 @@ class PostMessageCommunicator implements Communicator {
     if (Array.isArray(this.allowedOrigins)) {
       validOrigin = this.allowedOrigins.find((regExp) => regExp.test(origin)) !== undefined;
     }
-
+    console.log({ source, emptyOrMalformed, sentFromParentEl, allowedSDKVersion, validOrigin });
     return !emptyOrMalformed && sentFromParentEl && allowedSDKVersion && validOrigin;
   };
 
@@ -52,7 +52,7 @@ class PostMessageCommunicator implements Communicator {
     }
   };
 
-  public send = <M extends Methods, P, R>(method: M, params: P): Promise<Response<R>> => {
+  public send = <M extends Methods, P, R>(method: M, params: P): Promise<SuccessResponse<R>> => {
     const request = MessageFormatter.makeRequest(method, params);
 
     if (typeof window === 'undefined') {
@@ -60,8 +60,13 @@ class PostMessageCommunicator implements Communicator {
     }
 
     window.parent.postMessage(request, '*');
-    return new Promise((resolve) => {
+    return new Promise((resolve, reject) => {
       this.callbacks.set(request.id, (response: Response<R>) => {
+        if (!response.success) {
+          reject(new Error(response.error));
+          return;
+        }
+
         resolve(response);
       });
     });

--- a/packages/safe-apps-sdk/src/eth/index.ts
+++ b/packages/safe-apps-sdk/src/eth/index.ts
@@ -98,10 +98,6 @@ class Eth {
 
       const response = await this.communicator.send<Methods.rpcCall, RPCPayload<P>, R>(Methods.rpcCall, payload);
 
-      if (!response.success) {
-        throw new Error(response.error);
-      }
-
       return response.data;
     };
   }

--- a/packages/safe-apps-sdk/src/safe/index.ts
+++ b/packages/safe-apps-sdk/src/safe/index.ts
@@ -14,10 +14,6 @@ class Safe {
       undefined,
     );
 
-    if (!response.success) {
-      throw new Error(response.error);
-    }
-
     return response.data;
   }
 
@@ -29,10 +25,6 @@ class Safe {
         currency,
       },
     );
-
-    if (!response.success) {
-      throw new Error(response.error);
-    }
 
     return response.data;
   }

--- a/packages/safe-apps-sdk/src/txs/index.ts
+++ b/packages/safe-apps-sdk/src/txs/index.ts
@@ -25,10 +25,6 @@ class TXs {
       GatewayTransactionDetails
     >(Methods.getTxBySafeTxHash, { safeTxHash });
 
-    if (!response.success) {
-      throw new Error(response.error);
-    }
-
     return response.data;
   }
 
@@ -47,10 +43,6 @@ class TXs {
       SendTransactionsParams,
       SendTransactionsResponse
     >(Methods.sendTransactions, messagePayload);
-
-    if (!response.success) {
-      throw new Error(response.error);
-    }
 
     return response.data;
   }

--- a/packages/safe-apps-sdk/src/types/messaging.ts
+++ b/packages/safe-apps-sdk/src/types/messaging.ts
@@ -42,5 +42,5 @@ export type SuccessResponse<T = MethodToResponse[Methods]> = {
 export type Response<T = MethodToResponse[Methods]> = ErrorResponse | SuccessResponse<T>;
 
 export interface Communicator {
-  send<M extends Methods, P = unknown, R = unknown>(method: M, params: P): Promise<Response<R>>;
+  send<M extends Methods, P = unknown, R = unknown>(method: M, params: P): Promise<SuccessResponse<R>>;
 }


### PR DESCRIPTION
Currently, each method would implement a handler for the error case by itself. This could be moved one layer higher to the communication implementation.

**This PR:**
- Moves error handling to the communicator
- Adds a test case
- removes error handlers from methods

## remember to run `lerna run build` before merging to generate build files