### PR TITLE
Remove check for window for SSR

### DIFF
--- a/packages/safe-apps-sdk/src/sdk.ts
+++ b/packages/safe-apps-sdk/src/sdk.ts
@@ -16,10 +16,6 @@ class SafeAppsSDK {
   public readonly safe;
 
   constructor(opts: Opts = {}) {
-    if (typeof window === 'undefined') {
-      throw new Error('Error initializing the sdk: window is undefined');
-    }
-
     const { whitelistedDomains = null, debug = false } = opts;
 
     this.communicator = new InterfaceCommunicator(whitelistedDomains, debug);


### PR DESCRIPTION
This line will throw if you try to use it with Next.js for example. We want to support SSR, thus we remove this check