### PR TITLE
Remove npm token for changesets action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,4 +33,3 @@ jobs:
           publish: yarn release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
Related to #269 and the recent ban of automated publishing, I removed the npm token from the action, and their docs say it won't publish changes then. Let's merge it and test what it does instead