### PR TITLE
chore: bump gateway version

### DIFF
--- a/.changeset/nasty-jokes-sparkle.md
+++ b/.changeset/nasty-jokes-sparkle.md
@@ -1,0 +1,7 @@
+---
+'@gnosis.pm/safe-apps-sdk': minor
+'@gnosis.pm/safe-apps-web3-react': minor
+'@gnosis.pm/safe-apps-web3modal': minor
+---
+
+Bump safe-react-gateway-sdk deps to 2.9.0

--- a/packages/safe-apps-sdk/dist/package.json
+++ b/packages/safe-apps-sdk/dist/package.json
@@ -1,42 +1,42 @@
 {
-    "name": "@gnosis.pm/safe-apps-sdk",
-    "version": "7.0.0",
-    "description": "SDK developed to integrate third-party apps with Safe app.",
-    "main": "dist/src/index.js",
-    "typings": "dist/src/index.d.ts",
-    "_files": [
-        "dist/**/*",
-        "README.md"
-    ],
-    "keywords": [
-        "Gnosis",
-        "sdk",
-        "apps"
-    ],
-    "scripts": {
-        "test": "jest",
-        "format-dist": "sed -i 's/\"files\":/\"_files\":/' dist/package.json",
-        "build": "yarn rimraf dist && tsc && yarn format-dist",
-        "lint": "tslint -p tsconfig.json"
-    },
-    "author": "Gnosis (https://gnosis.io)",
-    "license": "MIT",
-    "dependencies": {
-        "@gnosis.pm/safe-react-gateway-sdk": "^2.8.5",
-        "ethers": "^5.4.7"
-    },
-    "devDependencies": {
-        "rimraf": "^3.0.2"
-    },
-    "repository": {
-        "type": "git",
-        "url": "git+https://github.com/gnosis/safe-apps-sdk.git"
-    },
-    "bugs": {
-        "url": "https://github.com/gnosis/safe-apps-sdk/issues"
-    },
-    "homepage": "https://github.com/gnosis/safe-apps-sdk#readme",
-    "publishConfig": {
-        "access": "public"
-    }
+  "name": "@gnosis.pm/safe-apps-sdk",
+  "version": "7.0.0",
+  "description": "SDK developed to integrate third-party apps with Safe app.",
+  "main": "dist/src/index.js",
+  "typings": "dist/src/index.d.ts",
+  "_files": [
+    "dist/**/*",
+    "README.md"
+  ],
+  "keywords": [
+    "Gnosis",
+    "sdk",
+    "apps"
+  ],
+  "scripts": {
+    "test": "jest",
+    "format-dist": "sed -i 's/\"files\":/\"_files\":/' dist/package.json",
+    "build": "yarn rimraf dist && tsc && yarn format-dist",
+    "lint": "tslint -p tsconfig.json"
+  },
+  "author": "Gnosis (https://gnosis.io)",
+  "license": "MIT",
+  "dependencies": {
+    "@gnosis.pm/safe-react-gateway-sdk": "^2.9.0",
+    "ethers": "^5.4.7"
+  },
+  "devDependencies": {
+    "rimraf": "^3.0.2"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/gnosis/safe-apps-sdk.git"
+  },
+  "bugs": {
+    "url": "https://github.com/gnosis/safe-apps-sdk/issues"
+  },
+  "homepage": "https://github.com/gnosis/safe-apps-sdk#readme",
+  "publishConfig": {
+    "access": "public"
+  }
 }

--- a/packages/safe-apps-sdk/package.json
+++ b/packages/safe-apps-sdk/package.json
@@ -22,7 +22,7 @@
   "author": "Gnosis (https://gnosis.io)",
   "license": "MIT",
   "dependencies": {
-    "@gnosis.pm/safe-react-gateway-sdk": "^2.8.5",
+    "@gnosis.pm/safe-react-gateway-sdk": "^2.9.0",
     "ethers": "^5.4.7"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1605,10 +1605,10 @@
     "@ethersproject/properties" "^5.5.0"
     "@ethersproject/strings" "^5.5.0"
 
-"@gnosis.pm/safe-react-gateway-sdk@^2.8.5":
-  version "2.8.5"
-  resolved "https://registry.yarnpkg.com/@gnosis.pm/safe-react-gateway-sdk/-/safe-react-gateway-sdk-2.8.5.tgz#3b82b993ae64a5fde1a96a4b0c47a97514839055"
-  integrity sha512-lrZ3gXzbNzIjIzYDs21d7I3fwwHi01YFnD+2+5Kuy0+fJAiONYXih2Z9Q4h3RS/AgzTHfL+G7WB6XB0V8GMVCQ==
+"@gnosis.pm/safe-react-gateway-sdk@^2.9.0":
+  version "2.9.0"
+  resolved "https://registry.yarnpkg.com/@gnosis.pm/safe-react-gateway-sdk/-/safe-react-gateway-sdk-2.9.0.tgz#04eb518dc5c8f9fadd637e20b09125c13aa87b88"
+  integrity sha512-I3FymJNmHsUVTv2BWXMZIuZbMadzyPslwyy4Fx9lf3qXwMuQrirBJvh4F54Q203Xv8Tcdtx88h3+Y69kaI7k8A==
   dependencies:
     isomorphic-unfetch "^3.1.0"
 


### PR DESCRIPTION
Resolves #292 

Bumps dependencies for safe-react-gateway-sdk to 2.9.0 

