### PR TITLE
chore: bump gateway version

### DIFF
--- a/.changeset/serious-suns-lie.md
+++ b/.changeset/serious-suns-lie.md
@@ -1,0 +1,7 @@
+---
+'@gnosis.pm/safe-apps-sdk': minor
+'@gnosis.pm/safe-apps-web3-react': minor
+'@gnosis.pm/safe-apps-web3modal': minor
+---
+
+Bump safe-react-gateway-sdk to the latest version

--- a/packages/safe-apps-sdk/dist/package.json
+++ b/packages/safe-apps-sdk/dist/package.json
@@ -4,7 +4,7 @@
     "description": "SDK developed to integrate third-party apps with Safe app.",
     "main": "dist/src/index.js",
     "typings": "dist/src/index.d.ts",
-    "_files": [
+    "files": [
         "dist/**/*",
         "README.md"
     ],
@@ -22,7 +22,7 @@
     "author": "Gnosis (https://gnosis.io)",
     "license": "MIT",
     "dependencies": {
-        "@gnosis.pm/safe-react-gateway-sdk": "^2.9.0",
+        "@gnosis.pm/safe-react-gateway-sdk": "^2.10.0",
         "ethers": "^5.4.7"
     },
     "devDependencies": {

--- a/packages/safe-apps-sdk/package.json
+++ b/packages/safe-apps-sdk/package.json
@@ -22,7 +22,7 @@
   "author": "Gnosis (https://gnosis.io)",
   "license": "MIT",
   "dependencies": {
-    "@gnosis.pm/safe-react-gateway-sdk": "^2.9.0",
+    "@gnosis.pm/safe-react-gateway-sdk": "^2.10.0",
     "ethers": "^5.4.7"
   },
   "devDependencies": {

--- a/packages/safe-apps-web3-react/README.md
+++ b/packages/safe-apps-web3-react/README.md
@@ -48,39 +48,13 @@ For the SDK overview documentation, please refer to the [safe-apps-sdk](https://
 
 ### NextJs
 
-Is you use a server side rendering solution as NextJs you might encounter some problems using the library and receive an error message like this:
-
-`self is not defined`
-
-The issue occurs because the library requires Web APIs to work, which are not available when Next.js pre-renders the page on the server-side. To fix it you can dynamically import a component so it only gets loaded on the client-side.
+Is you use a server side rendering solution remember to instantiate the connector inside an useEffect to avoid NextJS to process this server side where the `window` object does not exist.
 
 ```
-const SafeInfo = (props) => {
-  const [safeInfo, setSafeInfo] = React.useState(null);
-  const triedToConnectToSafe = useSafeAppConnection(safeMultisigConnector);
-
   React.useEffect(() => {
-    if (triedToConnectToSafe) {
-      safeMultisigConnector.getSafeInfo().then((safeInfo) => {
-        setSafeInfo(safeInfo);
-      });
-    }
-  }, [triedToConnectToSafe]);
-
-  if (!safeInfo) {
-    return null;
-  }
-
-  return (
-      <p> Safe address: {safeInfo.safeAddress}</p>
-  );
-};
-```
-
-And then, in your page:
-
-```
-const SafeInfo = dynamic(() => import('../components/SafeInfo'), {
-  ssr: false,
-});
+    const safeMultisigConnector = new SafeAppConnector();
+    safeMultisigConnector.getSafeInfo().then((safeInfo) => {
+      setSafeInfo(safeInfo);
+    });
+  }, []);
 ```

--- a/packages/safe-apps-web3modal/README.md
+++ b/packages/safe-apps-web3modal/README.md
@@ -45,14 +45,9 @@ const loadedAsSafeApp = await modal.isSafeApp();
 
 ### NextJs
 
-Is you use a server side rendering solution as NextJs you might encounter some problems using the library and receive an error message like this:
-
-`self is not defined`
-
-The issue occurs because the library requires Web APIs to work, which are not available when Next.js pre-renders the page on the server-side. To fix it you can dynamically import a component so it only gets loaded on the client-side.
+Is you use a server side rendering solution remember to instantiate the modal inside an useEffect to avoid NextJS to process this server side where the `window` object does not exist.
 
 ```
-const SafeInfoWeb3Modal = () => {
   const [provider, setProvider] = useState(null);
 
   useEffect(() => {
@@ -62,22 +57,4 @@ const SafeInfoWeb3Modal = () => {
       setProvider(provider);
     })();
   }, []);
-
-  if (!provider) {
-    return null;
-  }
-
-  return <p>Safe Address: {provider.safe.safeAddress}</p>;
-};
-```
-
-And then, in your page:
-
-```
-const SafeInfoWeb3Modal = dynamic(
-  () => import('../components/SafeInfoWeb3Modal'),
-  {
-    ssr: false,
-  }
-);
 ```

--- a/yarn.lock
+++ b/yarn.lock
@@ -1605,12 +1605,12 @@
     "@ethersproject/properties" "^5.5.0"
     "@ethersproject/strings" "^5.5.0"
 
-"@gnosis.pm/safe-react-gateway-sdk@^2.9.0":
-  version "2.9.0"
-  resolved "https://registry.yarnpkg.com/@gnosis.pm/safe-react-gateway-sdk/-/safe-react-gateway-sdk-2.9.0.tgz#04eb518dc5c8f9fadd637e20b09125c13aa87b88"
-  integrity sha512-I3FymJNmHsUVTv2BWXMZIuZbMadzyPslwyy4Fx9lf3qXwMuQrirBJvh4F54Q203Xv8Tcdtx88h3+Y69kaI7k8A==
+"@gnosis.pm/safe-react-gateway-sdk@^2.10.0":
+  version "2.10.0"
+  resolved "https://registry.yarnpkg.com/@gnosis.pm/safe-react-gateway-sdk/-/safe-react-gateway-sdk-2.10.0.tgz#88e2307d21d548ea43dde8fa33630d3539e39741"
+  integrity sha512-P0A6XgjpEwCzZpk0vjLOYuaOmXL020khJF9FQRwCYPrllPUzrGjpm5gdqExNdnefrrDUKeWUumkucoXqBaMblA==
   dependencies:
-    isomorphic-unfetch "^3.1.0"
+    cross-fetch "^3.1.5"
 
 "@humanwhocodes/config-array@^0.9.2":
   version "0.9.3"
@@ -3942,6 +3942,13 @@ cosmiconfig@^7.0.0:
     path-type "^4.0.0"
     yaml "^1.10.0"
 
+cross-fetch@^3.1.5:
+  version "3.1.5"
+  resolved "https://registry.yarnpkg.com/cross-fetch/-/cross-fetch-3.1.5.tgz#e1389f44d9e7ba767907f7af8454787952ab534f"
+  integrity sha512-lvb1SBsI0Z7GDwmuid+mU3kWVBwTVUbe7S0H52yaaAdQOXq2YktTCZdlAcNKFzE6QtRz0snpw9bNiPeOIkkQvw==
+  dependencies:
+    node-fetch "2.6.7"
+
 cross-spawn@^5.1.0:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-5.1.0.tgz#e8bd0efee58fcff6f8f94510a0a554bbfa235449"
@@ -5671,14 +5678,6 @@ isobject@^3.0.1:
   resolved "https://registry.yarnpkg.com/isobject/-/isobject-3.0.1.tgz#4e431e92b11a9731636aa1f9c8d1ccbcfdab78df"
   integrity sha1-TkMekrEalzFjaqH5yNHMvP2reN8=
 
-isomorphic-unfetch@^3.1.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/isomorphic-unfetch/-/isomorphic-unfetch-3.1.0.tgz#87341d5f4f7b63843d468438128cb087b7c3e98f"
-  integrity sha512-geDJjpoZ8N0kWexiwkX8F9NkTsXhetLPVbZFQ+JTW239QNOwvB0gniuR1Wc6f0AMTn7/mFGyXvHTifrCp/GH8Q==
-  dependencies:
-    node-fetch "^2.6.1"
-    unfetch "^4.2.0"
-
 isstream@~0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/isstream/-/isstream-0.1.2.tgz#47e63f7af55afa6f92e1500e690eb8b8529c099a"
@@ -6850,7 +6849,7 @@ neo-async@^2.6.0:
   resolved "https://registry.yarnpkg.com/neo-async/-/neo-async-2.6.2.tgz#b4aafb93e3aeb2d8174ca53cf163ab7d7308305f"
   integrity sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==
 
-node-fetch@^2.6.0, node-fetch@^2.6.1:
+node-fetch@2.6.7, node-fetch@^2.6.0, node-fetch@^2.6.1:
   version "2.6.7"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.7.tgz#24de9fba827e3b4ae44dc8b20256a379160052ad"
   integrity sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==
@@ -8918,11 +8917,6 @@ unbox-primitive@^1.0.1:
     has-bigints "^1.0.1"
     has-symbols "^1.0.2"
     which-boxed-primitive "^1.0.2"
-
-unfetch@^4.2.0:
-  version "4.2.0"
-  resolved "https://registry.yarnpkg.com/unfetch/-/unfetch-4.2.0.tgz#7e21b0ef7d363d8d9af0fb929a5555f6ef97a3be"
-  integrity sha512-F9p7yYCn6cIW9El1zi0HI6vqpeIvBsr3dSuRO6Xuppb1u5rXpCPmMvLSyECLhybr9isec8Ohl0hPekMVrEinDA==
 
 unicode-canonical-property-names-ecmascript@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
Resolves https://github.com/gnosis/safe-apps-sdk/issues/292

Bumps dependencies for safe-react-gateway-sdk to 2.9.0