### PR TITLE
fix(safe-apps-react-sdk): fix missing property `isReadOnly`

### DIFF
--- a/.changeset/rich-llamas-cry.md
+++ b/.changeset/rich-llamas-cry.md
@@ -1,0 +1,5 @@
+---
+"@gnosis.pm/safe-apps-react-sdk": patch
+---
+
+fix(safe-apps-react-sdk): fix missing property `isReadOnly`

--- a/packages/safe-apps-react-sdk/src/index.tsx
+++ b/packages/safe-apps-react-sdk/src/index.tsx
@@ -17,7 +17,13 @@ interface Props {
 export const SafeProvider: React.FC<Props> = ({ loader = null, opts, children }) => {
   const [sdk] = useState(() => new SafeAppsSDK(opts));
   const [connected, setConnected] = useState(false);
-  const [safe, setSafe] = useState<SafeInfo>({ safeAddress: '', chainId: 1, threshold: 1, owners: [] });
+  const [safe, setSafe] = useState<SafeInfo>({
+    safeAddress: '',
+    chainId: 1,
+    threshold: 1,
+    owners: [],
+    isReadOnly: true,
+  });
   const contextValue = useMemo(() => ({ sdk, connected, safe }), [sdk, connected, safe]);
 
   useEffect(() => {


### PR DESCRIPTION
Fix a missing mandatory property in SafeInfo init for `safe-apps-react-sdk` package