### PR TITLE
feat: Update docs to reflect manifest changes

### DIFF
--- a/guides/drain-safe-app/03-transfer-assets.md
+++ b/guides/drain-safe-app/03-transfer-assets.md
@@ -211,7 +211,6 @@ Let's get it ready for publishing. First, you need to update the `manifest.json`
   "short_name": "Safe App",
   "name": "Gnosis Safe App Starter",
   "description": "Describe your Safe App here",
-  "iconPath": "logo.svg",
   "icons": [
     {
       "src": "favicon.ico",
@@ -242,9 +241,15 @@ Let's add the name, short name, description and an icon:
   "short_name": "Drain Safe",
   "name": "Drain Safe",
   "description": "Migrate all your Safe assets in one transaction",
-  "iconPath": "logo.svg",
+  "icons": [
+    {
+      "src": "favicon.ico",
+      "sizes": "64x64 32x32 24x24 16x16",
+      "type": "image/x-icon"
+    }
+  ]
 ```
 
-Everything is self-explanatory, expect `iconPath` property that has to be a relative url from the URL app is hosted at.
+Everything is self-explanatory, expect `icons[n].src` property that has to be a relative url from the URL app is hosted at.
 
 Congrats! You've just made your first Safe app.

--- a/packages/cra-template-safe-app/template/public/manifest.json
+++ b/packages/cra-template-safe-app/template/public/manifest.json
@@ -2,8 +2,17 @@
   "short_name": "Safe App",
   "name": "Gnosis Safe App Starter",
   "description": "Describe your Safe App here",
-  "iconPath": "logo.svg",
   "icons": [
+    {
+      "src": "logo.svg",
+      "sizes": "any",
+      "type": "image/svg+xml"
+    },
+    {
+      "src": "favicon.ico",
+      "sizes": "64x64 32x32 24x24 16x16",
+      "type": "image/x-icon"
+    },
     {
       "src": "favicon.ico",
       "sizes": "64x64 32x32 24x24 16x16",

--- a/packages/safe-apps-sdk/README.md
+++ b/packages/safe-apps-sdk/README.md
@@ -332,9 +332,9 @@ It is mandatory that your app exposes a `manifest.json` file in the root dir wit
 }
 ```
 
-We are following the [Manifest spec](https://developer.mozilla.org/en-US/docs/Web/Manifest) for the manifest file. `description` is an optional field as is highlighted in the spec.
-
 > Note: icons[n].src it's the public relative path where the Safe will try to load your app icon. For this example, it should be https://yourAppUrl/myAppIcon.svg.
+
+We are following the [Manifest spec](https://developer.mozilla.org/en-US/docs/Web/Manifest) so you can find ore info about how to fill the `icons` field there.
 
 ### CORS
 

--- a/packages/safe-apps-sdk/README.md
+++ b/packages/safe-apps-sdk/README.md
@@ -322,11 +322,19 @@ It is mandatory that your app exposes a `manifest.json` file in the root dir wit
 {
   "name": "YourAppName",
   "description": "A description of what your app do",
-  "iconPath": "myAppIcon.svg"
+  "icons": [
+    {
+      "src": "/myAppIcon.svg",
+      "type": "image/svg+xml",
+      "sizes": "any"
+    }
+  ]
 }
 ```
 
-> Note: iconPath it's the public relative path where the Safe will try to load your app icon. For this example, it should be https://yourAppUrl/myAppIcon.svg.
+We are following the [Manifest spec](https://developer.mozilla.org/en-US/docs/Web/Manifest) for the manifest file. `description` and `icons` are optional as is highlighted in the spec.
+
+> Note: icons[n].src it's the public relative path where the Safe will try to load your app icon. For this example, it should be https://yourAppUrl/myAppIcon.svg.
 
 ### CORS
 

--- a/packages/safe-apps-sdk/README.md
+++ b/packages/safe-apps-sdk/README.md
@@ -334,7 +334,7 @@ It is mandatory that your app exposes a `manifest.json` file in the root dir wit
 
 > Note: icons[n].src it's the public relative path where the Safe will try to load your app icon. For this example, it should be https://yourAppUrl/myAppIcon.svg.
 
-We are following the [Manifest spec](https://developer.mozilla.org/en-US/docs/Web/Manifest) so you can find ore info about how to fill the `icons` field there.
+We are following the [Manifest spec](https://developer.mozilla.org/en-US/docs/Web/Manifest) so you can find more info about how to fill the `icons` field there.
 
 ### CORS
 

--- a/packages/safe-apps-sdk/README.md
+++ b/packages/safe-apps-sdk/README.md
@@ -332,7 +332,7 @@ It is mandatory that your app exposes a `manifest.json` file in the root dir wit
 }
 ```
 
-We are following the [Manifest spec](https://developer.mozilla.org/en-US/docs/Web/Manifest) for the manifest file. `description` and `icons` are optional as is highlighted in the spec.
+We are following the [Manifest spec](https://developer.mozilla.org/en-US/docs/Web/Manifest) for the manifest file. `description` is an optional field as is highlighted in the spec.
 
 > Note: icons[n].src it's the public relative path where the Safe will try to load your app icon. For this example, it should be https://yourAppUrl/myAppIcon.svg.
 


### PR DESCRIPTION
## What it solves 
Fixes gnosis/safe-react-apps#313

##  How this PR fixes it 
We are making `description` and `iconPath` properties optional. and adding support for the standard `icons` one
